### PR TITLE
Changed shebang to use env instead of an absolute path.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,4 +1,4 @@
-#!/usr/local/bin/node
+#!/usr/bin/env node
 "use strict";
 
 var fs = require("fs"),


### PR DESCRIPTION
So when I tried to run `renamer` I was consistently getting this error:

``` sh
bash: /usr/bin/renamer: /usr/local/bin/node: bad interpreter: No such file or directory
```

Turns out my copy of node was installed at `/usr/bin/node`, so that breaks the existing shebang directive. But changing it to `#!/usr/bin/env node` will find node wherever it exists. I also think it’s the defacto standard.

From [Unix and Node: Command-line Arguments](http://dailyjs.com/2012/03/01/unix-node-arguments/)

> Not all Unix systems use the same file system layout, and not all users want to install Node in the same place. Since the shebang must specify an absolute path, a common way around this is to introduce a level of indirection through `env`
